### PR TITLE
Update package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3565,8 +3565,8 @@
             "dev": true
         },
         "jquery": {
-            "version": "3.4.1",
-            "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.0.tgz",
             "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw=="
         },
         "jquery.easing": {


### PR DESCRIPTION
```
2 jquery vulnerabilities found in package-lock.json 4 hours ago
Remediation
Upgrade jquery to version 3.5.0 or later. For example:

"dependencies": {
  "jquery": ">=3.5.0"
}
or…
"devDependencies": {
  "jquery": ">=3.5.0"
}
Always verify the validity and compatibility of suggestions with your codebase.

Details
GHSA-jpcq-cgw6-v4j6
moderate severity
Vulnerable versions: >= 1.0.3, < 3.5.0
Patched version: 3.5.0
Impact
Passing HTML containing <option> elements from untrusted sources - even after sanitizing it - to one of jQuery's DOM manipulation methods (i.e. .html(), .append(), and others) may execute untrusted code.

Patches
This problem is patched in jQuery 3.5.0.

Workarounds
To workaround this issue without upgrading, use DOMPurify with its SAFE_FOR_JQUERY option to sanitize the HTML string before passing it to a jQuery method.

References
https://jquery.com/upgrade-guide/3.5/

For more information
If you have any questions or comments about this advisory:

Open an issue in the jQuery repo
Email us at security@jquery.com
GHSA-gxr4-xjj5-5px2
moderate severity
Vulnerable versions: >= 1.2, < 3.5.0
Patched version: 3.5.0
Impact
Passing HTML from untrusted sources - even after sanitizing it - to one of jQuery's DOM manipulation methods (i.e. .html(), .append(), and others) may execute untrusted code.

Patches
This problem is patched in jQuery 3.5.0.

Workarounds
To workaround the issue without upgrading, adding the following to your code:

jQuery.htmlPrefilter = function( html ) {
	return html;
};
You need to use at least jQuery 1.12/2.2 or newer to be able to apply this workaround.

References
https://blog.jquery.com/2020/04/10/jquery-3-5-0-released/
https://jquery.com/upgrade-guide/3.5/

For more information
If you have any questions or comments about this advisory:

Open an issue in the jQuery repo
Email us at security@jquery.com
```